### PR TITLE
Add useStateConst where update is always const

### DIFF
--- a/src/React/Basic/Hooks.purs
+++ b/src/React/Basic/Hooks.purs
@@ -7,6 +7,7 @@ module React.Basic.Hooks
   , ReactChildren
   , memo
   , useState
+  , useStateConst
   , UseState
   , useEffect
   , useEffectOnce
@@ -39,6 +40,7 @@ module React.Basic.Hooks
   ) where
 
 import Prelude hiding (bind, discard)
+import Data.Bifunctor (rmap)
 import Data.Function.Uncurried (Fn2, mkFn2)
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
@@ -164,6 +166,13 @@ useState ::
 useState initialState =
   unsafeHook do
     runEffectFn2 useState_ (mkFn2 Tuple) initialState
+
+useStateConst ::
+  forall state.
+  state ->
+  Hook (UseState state) (state /\ (state -> Effect Unit))
+useStateConst initialState =
+  useState initialState <#> rmap (_ <<< const)
 
 foreign import data UseState :: Type -> Type -> Type
 

--- a/src/React/Basic/Hooks.purs
+++ b/src/React/Basic/Hooks.purs
@@ -7,7 +7,7 @@ module React.Basic.Hooks
   , ReactChildren
   , memo
   , useState
-  , useStateConst
+  , useState'
   , UseState
   , useEffect
   , useEffectOnce
@@ -167,11 +167,11 @@ useState initialState =
   unsafeHook do
     runEffectFn2 useState_ (mkFn2 Tuple) initialState
 
-useStateConst ::
+useState' ::
   forall state.
   state ->
   Hook (UseState state) (state /\ (state -> Effect Unit))
-useStateConst initialState =
+useState' initialState =
   useState initialState <#> rmap (_ <<< const)
 
 foreign import data UseState :: Type -> Type -> Type


### PR DESCRIPTION
A common use case of `useState` does not rely on the update function. Adding `useStateConst` to address this. Not sure if I chose the best name though.