### PR TITLE
Add examples to useEffect docs

### DIFF
--- a/src/React/Basic/Hooks.purs
+++ b/src/React/Basic/Hooks.purs
@@ -183,7 +183,22 @@ foreign import data UseState :: Type -> Type -> Type
 -- | Runs the given effect when the component is mounted and any time the given
 -- | dependencies change. The effect should return its cleanup function. For
 -- | example, if the effect registers a global event listener, it should return
--- | and Effect which removes the listener.
+-- | an Effect which removes the listener.
+-- |
+-- | ```purs
+-- | useEffect deps do
+-- |   timeoutId <- setTimeout 1000 (logShow deps)
+-- |   pure (clearTimeout timeoutId)
+-- | ```
+-- | 
+-- | If no cleanup is needed, use `pure (pure unit)` or `pure mempty` to return
+-- | a no-op Effect
+-- |
+-- | ```purs
+-- | useEffect deps do
+-- |   logShow deps
+-- |   pure mempty
+-- | ```
 useEffect ::
   forall deps.
   Eq deps =>


### PR DESCRIPTION
There was a question on the [PureScript Discourse about how to use `useEffect`](https://discourse.purescript.org/t/cant-figure-out-how-to-use-react-basic-useeffect/1971), and I've fielded similar questions on the FP Slack from folks who were similarly confused about it, so I figured it might be worthwhile to add an example to the docs.