### PR TITLE
Correct useLayoutEffect documentation

### DIFF
--- a/src/React/Basic/Hooks.purs
+++ b/src/React/Basic/Hooks.purs
@@ -206,8 +206,10 @@ useEffectAlways effect = unsafeHook (runEffectFn1 useEffectAlways_ effect)
 
 foreign import data UseEffect :: Type -> Type -> Type
 
--- | Like `useEffect`, but the effect is performed on every render. Prefer `useEffect`
--- | with a proper dependency list whenever possible!
+-- | Like `useEffect`, but the effect is performed synchronously after the browser has
+-- | calculated layout. Useful for reading properties from the DOM that are not available
+-- | before layout, such as element sizes and positions. Prefer `useEffect` whenever
+-- | possible to avoid blocking browser painting.
 useLayoutEffect ::
   forall deps.
   Eq deps =>


### PR DESCRIPTION
I think the documentation for `useLayoutEffect` was copied from `useEffectAlways` without modification. I've replaced with a summary of the [reactjs.org documentation for `useLayoutEffect`](https://reactjs.org/docs/hooks-reference.html#uselayouteffect).