### PR TITLE
Use empty instead of mempty for Map, since Monoid instance dropped

### DIFF
--- a/src/React/Basic/Hooks/Suspense/Store.purs
+++ b/src/React/Basic/Hooks/Suspense/Store.purs
@@ -10,7 +10,7 @@ import Control.Alt ((<|>))
 import Data.DateTime.Instant (Instant, unInstant)
 import Data.Either (Either(..))
 import Data.Int (ceil)
-import Data.Map (Map, empty)
+import Data.Map (Map)
 import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.Newtype (un)
@@ -36,7 +36,7 @@ mkSuspenseStore ::
   (k -> Aff v) ->
   Effect (SuspenseStore k v)
 mkSuspenseStore defaultMaxAge backend = do
-  ref <- Ref.new empty
+  ref <- Ref.new Map.empty
   let
     isExpired maxAge now' (_ /\ d) = unInstant now' < unInstant d <> maxAge
 

--- a/src/React/Basic/Hooks/Suspense/Store.purs
+++ b/src/React/Basic/Hooks/Suspense/Store.purs
@@ -10,7 +10,7 @@ import Control.Alt ((<|>))
 import Data.DateTime.Instant (Instant, unInstant)
 import Data.Either (Either(..))
 import Data.Int (ceil)
-import Data.Map (Map)
+import Data.Map (Map, empty)
 import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.Newtype (un)
@@ -36,7 +36,7 @@ mkSuspenseStore ::
   (k -> Aff v) ->
   Effect (SuspenseStore k v)
 mkSuspenseStore defaultMaxAge backend = do
-  ref <- Ref.new mempty
+  ref <- Ref.new empty
   let
     isExpired maxAge now' (_ /\ d) = unInstant now' < unInstant d <> maxAge
 


### PR DESCRIPTION
See https://github.com/purescript/purescript-ordered-collections/pull/38